### PR TITLE
Update readme with submodule instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@
 </div>
 
 # calendso-docker
+
 The Docker configuration for Calendso is an effort powered by people within the community. Calendso does not provide official support for Docker, but we will accept fixes and documentation. Use at your own risk.
 
 ## Requirements
+
 Make sure you have `docker` & `docker-compose` installed on the server / system.
 
 ## Getting Started
@@ -21,25 +23,51 @@ Make sure you have `docker` & `docker-compose` installed on the server / system.
     ```bash
     git clone --recursive https://github.com/calendso/docker.git calendso-docker
     ```
+
 2. Change into the directory
 
     ```bash
     cd calendso-docker
     ```
-3. Update `.env` if needed 
+
+3. Update `.env` if needed
 
 4. Build and start calendso
 
-    ```
+    ```bash
     docker-compose up --build
     ```
 
-5. Start prisma studio 
-    ```
+5. Start prisma studio
+
+    ```bash
     docker-compose exec calendso npx prisma studio
     ```
+
 6. Open a browser to [http://localhost:5555](http://localhost:5555) to look at or modify the database content.
 
 7. Click on the `User` model to add a new user record.
-8.  Fill out the fields (remembering to encrypt your password with [BCrypt](https://bcrypt-generator.com/)) and click `Save 1 Record` to create your first user.
+
+8. Fill out the fields (remembering to encrypt your password with [BCrypt](https://bcrypt-generator.com/)) and click `Save 1 Record` to create your first user.
+
 9. Open a browser to [http://localhost:3000](http://localhost:3000) and login with your just created, first user.
+
+## Git Submodules
+
+This repository uses a git submodule.
+
+If you cloned the repository without using `--recursive`, then you can initialize and clone the submodule with the following steps.
+
+1. Init the submodule
+
+    ```bash
+    git submodule init
+    ```
+
+2. Update the submodule
+
+    ```bash
+    git submodule update --remote
+    ```
+
+For more advanced usage, please refer to the git documentation: [https://git-scm.com/book/en/v2/Git-Tools-Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules)


### PR DESCRIPTION
The readme is missing information on submodules which may be confusing to new contributors.

I added a section for Git Submodules, as well as performed minor formatting cleanup in Readme.