### PR TITLE
Add support for Doppler

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.env
+**/node_modules

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,4 @@
-POSTGRES_USER=unicorn_user
-POSTGRES_PASSWORD=magical_password
-POSTGRES_DB=calendso
-DATABASE_HOST=db:5432
-DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}/${POSTGRES_DB}"
+DATABASE_URL="postgresql://unicorn_user:magical_password@db:5432/cal"
 GOOGLE_API_CREDENTIALS='secret'
 BASE_URL='http://localhost:3000'
 NEXTAUTH_URL='http://localhost:3000'

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 # .env file
 .env
+node_modules/

--- a/README.md
+++ b/README.md
@@ -20,29 +20,31 @@ Make sure you have `docker` & `docker-compose` installed on the server / system.
 
 1. Clone calendso-docker
 
-    ```bash
-    git clone --recursive https://github.com/calendso/docker.git calendso-docker
-    ```
+   ```bash
+   git clone --recursive https://github.com/calendso/docker.git calendso-docker
+   ```
 
 2. Change into the directory
 
-    ```bash
-    cd calendso-docker
-    ```
+   ```bash
+   cd calendso-docker
+   ```
 
-3. Rename `.env.example` to `.env` and update `.env` if needed.
+3. Rename `.env.example` to `.env` and update if needed.
+   For local development and production use-cases, jump to the [Secrets Management](#secrets-management) section.
+   **We strongly encourage using a secrets manager to securely store secrets. ENV files lead to accidental leaks and breaches.**
 
 4. Build and start calendso
 
-    ```bash
-    docker-compose up --build
-    ```
+   ```bash
+   docker-compose up --build
+   ```
 
 5. Start prisma studio
 
-    ```bash
-    docker-compose exec calendso npx prisma studio
-    ```
+   ```bash
+   docker-compose exec calendso npx prisma studio
+   ```
 
 6. Open a browser to [http://localhost:5555](http://localhost:5555) to look at or modify the database content.
 
@@ -52,6 +54,26 @@ Make sure you have `docker` & `docker-compose` installed on the server / system.
 
 9. Open a browser to [http://localhost:3000](http://localhost:3000) and login with your just created, first user.
 
+## Secrets Management
+
+We strongly recommend using [Doppler](https://doppler.com) to securely store and manage secrets across devices, environments, and team members.
+
+1. Import our project to get setup.
+
+   <a href="https://dashboard.doppler.com/workplace/template/import?template=https://github.com/calendso/docker/blob/main/doppler.yaml"/>
+      <img src="https://raw.githubusercontent.com/DopplerUniversity/app-config-templates/main/doppler-button.svg" alt="Import to Doppler" />
+   </a>
+
+2. Create a service token.
+
+   ![create-service-token](https://user-images.githubusercontent.com/1920007/141717862-a524c1ad-9384-4f40-909f-4d293e4889e2.gif)
+
+3. Build and start calendso with Doppler
+
+   ```bash
+   DOPPLER_TOKEN=dp.st.XXXXXXX docker-compose up --build
+   ```
+
 ## Git Submodules
 
 This repository uses a git submodule.
@@ -60,14 +82,14 @@ If you cloned the repository without using `--recursive`, then you can initializ
 
 1. Init the submodule
 
-    ```bash
-    git submodule init
-    ```
+   ```bash
+   git submodule init
+   ```
 
 2. Update the submodule
 
-    ```bash
-    git submodule update --remote
-    ```
+   ```bash
+   git submodule update --remote
+   ```
 
 For more advanced usage, please refer to the git documentation: [https://git-scm.com/book/en/v2/Git-Tools-Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,12 +1,15 @@
 # Use postgres/example user/password credentials
-version: '3.1'
+version: "3.1"
 services:
   db:
     image: postgres
     restart: always
     volumes:
       - database-data:/var/lib/postgresql/data/
-    env_file: .env
+    environment:
+      POSTGRES_USER: "unicorn_user"
+      POSTGRES_PASSWORD: "magical_password"
+      POSTGRES_DB: "cal"
     ports:
       - 5432:5432
   calendso:
@@ -15,9 +18,8 @@ services:
     ports:
       - 3000:3000
       - 5555:5555
-    env_file: .env
     environment:
-      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}/${POSTGRES_DB}
+      - DOPPLER_TOKEN
     depends_on:
       - db
 volumes:

--- a/doppler.yaml
+++ b/doppler.yaml
@@ -1,0 +1,77 @@
+projects:
+  - name: "cal"
+    description: "Cal.com configuration and secrets"
+    environments:
+      - name: "Development"
+        slug: "dev"
+        configs:
+          - slug: "dev"
+
+      - name: "Production"
+        slug: "prd"
+        configs:
+          - slug: "prd"
+    secrets:
+      dev:
+        NODE_ENV: "development"
+        DATABASE_HOST: "db:5432"
+        DATABASE_URL: "postgresql://unicorn_user:magical_password@${DATABASE_HOST}/cal"
+        GOOGLE_API_CREDENTIALS: "secret"
+        BASE_URL: "http://localhost:3000"
+        NEXTAUTH_URL: "http://localhost:3000"
+
+        # Remove this var if you don't want Calendso to collect anonymous usage
+        NEXT_PUBLIC_TELEMETRY_KEY: "js.2pvs2bbpqq1zxna97wcml.oi2jzirnbj1ev4tc57c5r"
+
+        # Used for the Office 365 / Outlook.com Calendar integration
+        MS_GRAPH_CLIENT_ID: ""
+        MS_GRAPH_CLIENT_SECRET: ""
+
+        # Used for the Zoom integration
+        ZOOM_CLIENT_ID: ""
+        ZOOM_CLIENT_SECRET: ""
+
+        # E-mail settings
+        # Configures the global From: header whilst sending emails.
+        EMAIL_FROM: "notifications@example.com"
+
+        # Configure SMTP settings (@see https://nodemailer.com/smtp/).
+        EMAIL_SERVER_HOST: "smtp.example.com"
+        EMAIL_SERVER_PORT: "587"
+        EMAIL_SERVER_USER: "email_user"
+        EMAIL_SERVER_PASSWORD: "email_password"
+
+        # Encryption key that will be used to encrypt CalDAV credentials, choose a random string, for example with `dd if=/dev/urandom bs=1K count=1 | md5sum`
+        CALENDSO_ENCRYPTION_KEY: ""
+
+      prd:
+        NODE_ENV: "production"
+        DATABASE_HOST: ""
+        DATABASE_URL: ""
+        GOOGLE_API_CREDENTIALS: "secret"
+        BASE_URL: ""
+        NEXTAUTH_URL: ""
+
+        # Remove this var if you don't want Calendso to collect anonymous usage
+        NEXT_PUBLIC_TELEMETRY_KEY: "js.2pvs2bbpqq1zxna97wcml.oi2jzirnbj1ev4tc57c5r"
+
+        # Used for the Office 365 / Outlook.com Calendar integration
+        MS_GRAPH_CLIENT_ID: ""
+        MS_GRAPH_CLIENT_SECRET: ""
+
+        # Used for the Zoom integration
+        ZOOM_CLIENT_ID: ""
+        ZOOM_CLIENT_SECRET: ""
+
+        # E-mail settings
+        # Configures the global From: header whilst sending emails.
+        EMAIL_FROM: "notifications@example.com"
+
+        # Configure SMTP settings (@see https://nodemailer.com/smtp/).
+        EMAIL_SERVER_HOST: "smtp.example.com"
+        EMAIL_SERVER_PORT: "587"
+        EMAIL_SERVER_USER: "email_user"
+        EMAIL_SERVER_PASSWORD: "email_password"
+
+        # Encryption key that will be used to encrypt CalDAV credentials, choose a random string, for example with `dd if=/dev/urandom bs=1K count=1 | md5sum`
+        CALENDSO_ENCRYPTION_KEY: ""

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
-set -x
 
-/app/scripts/wait-for-it.sh ${DATABASE_HOST} -- echo "db is up"
+/app/scripts/wait-for-it.sh ${DATABASE_HOST} -- echo "db is up";
 npx prisma migrate deploy
-yarn start
+yarn start;


### PR DESCRIPTION
Hey Cal community! Excited to add [Doppler](https://doppler.com) support for secure secrets management. Guide to using Doppler with Cal:

1. Import our project to get setup.

   <a href="https://dashboard.doppler.com/workplace/template/import?template=https://github.com/bvallelunga/docker/blob/main/doppler.yaml"/>
      <img src="https://raw.githubusercontent.com/DopplerUniversity/app-config-templates/main/doppler-button.svg" alt="Import to Doppler" />
   </a>

2. Create a service token.

   ![create-service-token](https://user-images.githubusercontent.com/1920007/141717862-a524c1ad-9384-4f40-909f-4d293e4889e2.gif)

3. Build and start calendso with Doppler

   ```bash
   DOPPLER_TOKEN=dp.st.XXXXXXX docker-compose up --build
   ```