### PR TITLE
docker-compose port use .env variable or default :3000

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,7 +32,7 @@ services:
     networks:
       - stack
     ports:
-      - 3000:3000
+       - ${PORT-3000}:3000
     env_file: .env
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}/${POSTGRES_DB}


### PR DESCRIPTION
make it possible to overwrite the :3000 port using .env instead of modifying docker-compose.yaml file