### PR TITLE
Update Dockerfile to use workspaces setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM node:14 as deps
 
 WORKDIR /calcom
-COPY calendso/apps/web/package.json calendso/apps/web/yarn.lock ./
-COPY calendso/apps/web/prisma prisma
+COPY calendso/package.json calendso/yarn.lock ./
+COPY calendso/apps/web/package.json calendso/apps/web/yarn.lock ./apps/web/
+COPY calendso/packages/prisma/package.json ./packages/prisma/package.json
+COPY calendso/packages/lib/package.json ./packages/lib/package.json
+COPY calendso/packages/tsconfig/package.json ./packages/tsconfig/package.json
 # RUN yarn install --frozen-lockfile
 RUN yarn install
 
@@ -12,30 +15,33 @@ WORKDIR /calcom
 ARG BASE_URL
 ARG NEXT_PUBLIC_APP_URL
 ARG NEXT_PUBLIC_LICENSE_CONSENT
-ARG NEXT_PUBLIC_TELEMETRY_KEY 
+ARG NEXT_PUBLIC_TELEMETRY_KEY
 ENV BASE_URL=$BASE_URL \
     NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL \
     NEXT_PUBLIC_LICENSE_CONSENT=$NEXT_PUBLIC_LICENSE_CONSENT \
     NEXT_PUBLIC_TELEMETRY_KEY=$NEXT_PUBLIC_TELEMETRY_KEY
-    
+
+COPY calendso/package.json calendso/yarn.lock calendso/turbo.json ./
 COPY calendso/apps/web ./apps/web
 COPY calendso/packages ./packages
-COPY --from=deps /calcom/node_modules ./apps/web/node_modules
-WORKDIR /calcom/apps/web
+COPY --from=deps /calcom/node_modules ./node_modules
 RUN yarn build && yarn install --production --ignore-scripts --prefer-offline
 
 FROM node:14 as runner
 WORKDIR /calcom
 ENV NODE_ENV production
+RUN apt-get update && apt-get -y install netcat && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /calcom/apps/web/node_modules ./node_modules
-COPY --from=builder /calcom/apps/web/prisma ./prisma
-COPY --from=builder /calcom/apps/web/scripts ./scripts
-COPY --from=builder /calcom/apps/web/next.config.js ./
-COPY --from=builder /calcom/apps/web/next-i18next.config.js ./
-COPY --from=builder /calcom/apps/web/public ./public
-COPY --from=builder /calcom/apps/web/.next ./.next
-COPY --from=builder /calcom/apps/web/package.json ./package.json
+COPY calendso/package.json calendso/yarn.lock calendso/turbo.json ./
+COPY --from=builder /calcom/node_modules ./node_modules
+COPY --from=builder /calcom/packages ./packages
+COPY --from=builder /calcom/apps/web/node_modules ./apps/web/node_modules
+COPY --from=builder /calcom/apps/web/scripts ./apps/web/scripts
+COPY --from=builder /calcom/apps/web/next.config.js ./apps/web/next.config.js
+COPY --from=builder /calcom/apps/web/next-i18next.config.js ./apps/web/next-i18next.config.js
+COPY --from=builder /calcom/apps/web/public ./apps/web/public
+COPY --from=builder /calcom/apps/web/.next ./apps/web/.next
+COPY --from=builder /calcom/apps/web/package.json ./apps/web/package.json
 COPY  scripts scripts
 
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,10 @@ RUN yarn build && yarn install --production --ignore-scripts --prefer-offline
 FROM node:14 as runner
 WORKDIR /calcom
 ENV NODE_ENV production
-RUN apt-get update && apt-get -y install netcat && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get -y install netcat && \
+    rm -rf /var/lib/apt/lists/* && \
+    npm install --global prisma
 
 COPY calendso/package.json calendso/yarn.lock calendso/turbo.json ./
 COPY --from=builder /calcom/node_modules ./node_modules

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,6 @@ services:
         - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL}
         - NEXT_PUBLIC_LICENSE_CONSENT=${NEXT_PUBLIC_LICENSE_CONSENT}
         - NEXT_PUBLIC_TELEMETRY_KEY=${NEXT_PUBLIC_TELEMETRY_KEY}
-    image: calendso/calendso:latest
     restart: always
     networks:
       - stack

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -2,5 +2,5 @@
 set -x
 
 /calcom/scripts/wait-for-it.sh ${DATABASE_HOST} -- echo "database is up"
-# npx prisma migrate deploy --schema /calcom/packages/prisma/schema.prisma
+npx prisma migrate deploy --schema /calcom/packages/prisma/schema.prisma
 yarn start

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -x
 
-/app/scripts/wait-for-it.sh ${DATABASE_HOST} -- echo "database is up"
-npx prisma migrate deploy
+/calcom/scripts/wait-for-it.sh ${DATABASE_HOST} -- echo "database is up"
+# npx prisma migrate deploy --schema /calcom/packages/prisma/schema.prisma
 yarn start

--- a/scripts/wait-for-it.sh
+++ b/scripts/wait-for-it.sh
@@ -54,7 +54,7 @@ wait_for() {
       ;;
     wget)
       if ! command -v wget >/dev/null; then
-        echoerr 'nc command is missing!'
+        echoerr 'wget command is missing!'
         exit 1
       fi
       ;;
@@ -62,11 +62,11 @@ wait_for() {
 
   while :; do
     case "$PROTOCOL" in
-      tcp) 
+      tcp)
         nc -w 1 -z "$HOST" "$PORT" > /dev/null 2>&1
         ;;
       http)
-        wget --timeout=1 -q "$HOST" -O /dev/null > /dev/null 2>&1 
+        wget --timeout=1 -q "$HOST" -O /dev/null > /dev/null 2>&1
         ;;
       *)
         echoerr "Unknown protocol '$PROTOCOL'"
@@ -75,7 +75,7 @@ wait_for() {
     esac
 
     result=$?
-        
+
     if [ $result -eq 0 ] ; then
       if [ $# -gt 7 ] ; then
         for result in $(seq $(($# - 7))); do


### PR DESCRIPTION
The main Cal.com project has started using Yarn workspaces to
break the project up into separate packages and treat the project
as a monorepo. This required quite a few changes to the Dockerfile
that assumed the previous project setup.

This should fix #84 and #85.