### PR TITLE
Remove recursive flag on clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Note: `docker compose` without the hyphen is now the primary method of using doc
 1. Clone calcom-docker
 
     ```bash
-    git clone --recursive https://github.com/calcom/docker.git calcom-docker
+    git clone https://github.com/calcom/docker.git calcom-docker
     ```
 
 2. Change into the directory


### PR DESCRIPTION
The --recursive flag in the clone instructions causes the clonse to break, because some submodules are private.