### PR TITLE
Revert removal of prisma schema

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ COPY calcom/package.json calcom/yarn.lock calcom/turbo.json ./
 COPY --from=builder /calcom/node_modules ./node_modules
 COPY --from=builder /calcom/packages ./packages
 COPY --from=builder /calcom/apps/web ./apps/web
+COPY --from=builder /calcom/packages/prisma/schema.prisma ./prisma/schema.prisma
 COPY scripts scripts
 
 EXPOSE 3000


### PR DESCRIPTION
The prisma schema file was removed in the previous dockerfile change.
This adds it back.

(prisma studio would have still worked until the updated docker build was successfully pushed last night)