### PR TITLE
Add app seed script to startup

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -3,4 +3,5 @@ set -x
 
 scripts/wait-for-it.sh ${DATABASE_HOST} -- echo "database is up"
 npx prisma migrate deploy --schema /calcom/packages/prisma/schema.prisma
+npx ts-node --transpile-only /calcom/packages/prisma/seed-app-store.ts
 yarn start


### PR DESCRIPTION
Apps are upserted into the database depending on the availability of certain env variables.
This operation is now performed at startup, and is not required during build.

Please see https://github.com/calcom/cal.com/blob/main/packages/prisma/seed-app-store.ts for further details

closes #126 