### PR TITLE
Specify image in build, for removal of build requirement in docs

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,6 +21,7 @@ services:
       - stack
 
   calcom:
+    image: calendso/calendso:latest
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
do not merge yet

Recent updates support variable substitution at runtime, so the docs need to be updated to reflect those options.
(not to remove the build steps altogether, but to move them to a new section and clarify Run requirements)

With this change to docker-compose.yml,
1. Run `docker compose pull`
then
2. Run `docker compose up`