### PR TITLE
Use Scarf endpoint for Cal.com container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,7 +45,7 @@ services:
 
 # Optional use of Prisma Studio. In production, comment out or remove the section below to prevent unwanted access to your database.
   studio:
-    image: calendso/calendso:latest
+    image: calcom.docker.scarf.sh/calendso/calendso:latest
     restart: always
     networks:
       - stack


### PR DESCRIPTION
Update docker-compose.yaml to utilize Scarf endpoint for the Cal.com container. Scarf is a tool that allows maintainers to track open-source project adoption and usage metrics. Updating the image references in the `docker-compose.yaml` file to redirect through Scarf first lets these metrics be collected for product improvement