### PR TITLE
add preinstall script dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV NEXT_PUBLIC_WEBAPP_URL=http://NEXT_PUBLIC_WEBAPP_URL_PLACEHOLDER \
     CALENDSO_ENCRYPTION_KEY=${CALENDSO_ENCRYPTION_KEY} \
     NODE_OPTIONS=--max-old-space-size=${MAX_OLD_SPACE_SIZE}
 
-COPY calcom/package.json calcom/yarn.lock calcom/turbo.json ./
+COPY calcom/package.json calcom/yarn.lock calcom/turbo.json calcom/git-init.sh calcom/git-setup.sh ./
 COPY calcom/apps/web ./apps/web
 COPY calcom/packages ./packages
 


### PR DESCRIPTION
recent changes in the main repository added a `preinstall` step:

https://github.com/calcom/cal.com/commit/8d078564dda8d9fea38ef562317f95f5378f61ac

these scripts need to be in the container in order for turbo to properly run all steps without error. without them, the build step will error, complaining about a missing `.git-init.sh` script