### PR TITLE
Remove note about Docker organization not renamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@
 
 # Docker
 
-NOTE: DockerHub organization has not yet been renamed.
-
 This image can be found on DockerHub at [https://hub.docker.com/r/calcom/cal.com](https://hub.docker.com/r/calcom/cal.com)
 
 The Docker configuration for Cal.com is an effort powered by people within the community. Cal.com, Inc. does not yet provide official support for Docker, but we will accept fixes and documentation at this time. Use at your own risk.


### PR DESCRIPTION
It has been renamed and the README was updated by 23930c073f6773b0ee8207fdb57bd9fb1f93f59b.