### PR TITLE
Remove version property in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,4 @@
 # Use postgres/example user/password credentials
-version: '3.8'
 
 volumes:
   database-data:


### PR DESCRIPTION
The `version` property in the `docker-compose.yaml` is only informative and of no use, therefore it should be removed.

See [docs.docker.com](https://docs.docker.com/compose/compose-file/04-version-and-name/).