### PR TITLE
Fix shellcheck issues

### DIFF
--- a/scripts/replace-placeholder.sh
+++ b/scripts/replace-placeholder.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 FROM=$1
 TO=$2
 
@@ -11,6 +13,6 @@ fi
 echo "Replacing all statically built instances of $FROM with $TO."
 
 find apps/web/.next/ apps/web/public -type f |
-while read file; do
+while read -r file; do
     sed -i "s|$FROM|$TO|g" "$file"
 done

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -5,7 +5,7 @@ set -x
 # NOTE: if these values are the same, this will be skipped.
 scripts/replace-placeholder.sh "$BUILT_NEXT_PUBLIC_WEBAPP_URL" "$NEXT_PUBLIC_WEBAPP_URL"
 
-scripts/wait-for-it.sh ${DATABASE_HOST} -- echo "database is up"
+scripts/wait-for-it.sh "${DATABASE_HOST}" -- echo "database is up"
 npx prisma migrate deploy --schema /calcom/packages/prisma/schema.prisma
 npx ts-node --transpile-only /calcom/packages/prisma/seed-app-store.ts
 yarn start


### PR DESCRIPTION
Fixes the [shellcheck](https://www.shellcheck.net/) issues [SC2148](https://www.shellcheck.net/wiki/SC2148), [SC2086](https://www.shellcheck.net/wiki/SC2086) and [SC2162](https://www.shellcheck.net/wiki/SC2162).

```sh
In /github/workspace/scripts/replace-placeholder.sh line 1:
FROM=$1
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In /github/workspace/scripts/replace-placeholder.sh line 14:
while read file; do
      ^--^ SC2162 (info): read without -r will mangle backslashes.


In /github/workspace/scripts/start.sh line 8:
scripts/wait-for-it.sh ${DATABASE_HOST} -- echo "database is up"
                       ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
scripts/wait-for-it.sh "${DATABASE_HOST}" -- echo "database is up"

For more information:
  https://www.shellcheck.net/wiki/SC2148 -- Tips depend on target shell and y...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2162 -- read without -r will mangle backs...
```