### PR TITLE
fix: add missing tests folder required for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ COPY calcom/package.json calcom/yarn.lock calcom/.yarnrc.yml calcom/playwright.c
 COPY calcom/.yarn ./.yarn
 COPY calcom/apps/web ./apps/web
 COPY calcom/packages ./packages
+COPY calcom/tests ./tests
 
 RUN yarn config set httpTimeout 1200000 && \ 
     npx turbo prune --scope=@calcom/web --docker && \


### PR DESCRIPTION
cal.com v3.2.9 has a new tests folder. The Docker image build fails without it.