### PR TITLE
Push all tags not just first one in build & push workflow

### DIFF
--- a/.github/workflows/docker-build-push-dockerhub.yml
+++ b/.github/workflows/docker-build-push-dockerhub.yml
@@ -168,9 +168,9 @@ jobs:
         run: |
           tags="${{ steps.meta.outputs.tags }}"
           IFS=',' read -ra ADDR <<< "$tags"  # Convert string to array using ',' as delimiter
-          tag=${ADDR[0]}  # Get the first tag
-          
-          docker push $tag
+          for tag in "${ADDR[@]}"; do
+            docker push $tag
+          done
 
 
       - name: Cleanup


### PR DESCRIPTION
Currently it only pushes the first tag. And I notice that despite workflow being successful, we don't see new release on dockerhub. Perhaps we need to push all the tags to dockerhub and not just the first one.