### PR TITLE
Reuse docker-build-push action to push multiple images

### DIFF
--- a/.github/workflows/docker-build-push-dockerhub.yml
+++ b/.github/workflows/docker-build-push-dockerhub.yml
@@ -118,10 +118,6 @@ jobs:
             NEXT_PUBLIC_LICENSE_CONSENT=${{ env.NEXT_PUBLIC_LICENSE_CONSENT }}
             NEXT_PUBLIC_TELEMETRY_KEY=${{ env.NEXT_PUBLIC_TELEMETRY_KEY }}
             DATABASE_URL=postgresql://${{ env.POSTGRES_USER }}:${{ env.POSTGRES_PASSWORD }}@${{ env.DATABASE_HOST }}/${{ env.POSTGRES_DB }}
-                      
-      # - name: Build with docker compose
-      #   run: |
-      #     DOCKER_BUILDKIT=0 docker compose build --build-arg DATABASE_URL=postgresql://${{ env.POSTGRES_USER }}:${{ env.POSTGRES_PASSWORD }}@${{ env.DATABASE_HOST }}/${{ env.POSTGRES_DB }} calcom
 
       - name: Test runtime
         run: |
@@ -182,7 +178,7 @@ jobs:
         with:
           context: ./
           file: ./Dockerfile
-          push: true  # Do not push the image at this stage
+          push: true 
           platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build-push-dockerhub.yml
+++ b/.github/workflows/docker-build-push-dockerhub.yml
@@ -163,19 +163,34 @@ jobs:
         env:
           NEXTAUTH_SECRET: 'EI4qqDpcfdvf4A+0aQEEx8JjHxHSy4uWiZw/F32K+pA='
           CALENDSO_ENCRYPTION_KEY: '0zfLtY99wjeLnsM7qsa8xsT+Q0oSgnOL'
-
-      - name: Push image
-        run: |
-          tags="${{ steps.meta.outputs.tags }}"
-          IFS=',' read -ra ADDR <<< "$tags"  # Convert string to array using ',' as delimiter
-          for tag in "${ADDR[@]}"; do
-            docker push $tag
-          done
-
-
+          
       - name: Cleanup
         run: |
           docker compose down
+
+      # - name: Push image
+      #   run: |
+      #     tags="${{ steps.meta.outputs.tags }}"
+      #     IFS=',' read -ra ADDR <<< "$tags"  # Convert string to array using ',' as delimiter
+      #     for tag in "${ADDR[@]}"; do
+      #       docker push $tag
+      #     done
+
+      - name: Push image
+        id: docker_push
+        uses: docker/build-push-action@v4
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true  # Do not push the image at this stage
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            NEXT_PUBLIC_WEBAPP_URL=${{ env.NEXT_PUBLIC_WEBAPP_URL }}
+            NEXT_PUBLIC_LICENSE_CONSENT=${{ env.NEXT_PUBLIC_LICENSE_CONSENT }}
+            NEXT_PUBLIC_TELEMETRY_KEY=${{ env.NEXT_PUBLIC_TELEMETRY_KEY }}
+            DATABASE_URL=postgresql://${{ env.POSTGRES_USER }}:${{ env.POSTGRES_PASSWORD }}@${{ env.DATABASE_HOST }}/${{ env.POSTGRES_DB }}
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
This reuses the docker-build-push action for the push step. Ideally this will not rebuild and will simply push.
Ref: https://docs.docker.com/build/ci/github-actions/test-before-push/

This also moves the docker compose cleanup to prior to the final push step