### PR TITLE
Identify pre-release in Create Release workflow

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -39,6 +39,7 @@ jobs:
         with:
           github-token: "${{ secrets.ACTIONS_ACCESS_TOKEN }}"
           script: |
+            const isPreRelease = '${{ inputs.RELEASE_TAG }}'.includes('-rc'); 
             try {
               const response = await github.rest.repos.createRelease({
                 draft: false,
@@ -47,7 +48,7 @@ jobs:
                 name: '${{ inputs.RELEASE_TAG }}',
                 target_commitish: 'release-${{ inputs.RELEASE_TAG }}',
                 owner: context.repo.owner,
-                prerelease: false,
+                prerelease: isPreRelease,
                 repo: context.repo.repo,
                 tag_name: '${{ inputs.RELEASE_TAG }}',
               });

--- a/.github/workflows/docker-build-push-dockerhub.yml
+++ b/.github/workflows/docker-build-push-dockerhub.yml
@@ -78,6 +78,7 @@ jobs:
           # Add flavor latest only on full releases, not on pre-releases
           flavor: |
             latest=${{ !github.event.release.prerelease }}
+            prerelease=${{ github.event.release.prerelease }}
 
       - name: Copy env
         run: |

--- a/.github/workflows/docker-build-push-dockerhub.yml
+++ b/.github/workflows/docker-build-push-dockerhub.yml
@@ -75,6 +75,9 @@ jobs:
             docker.io/calendso/calendso
             docker.io/calcom/cal.com
             ghcr.io/calcom/cal.com
+          # Add flavor latest only on full releases, not on pre-releases
+          flavor: |
+            latest=${{ !github.event.release.prerelease }}
 
       - name: Copy env
         run: |
@@ -184,7 +187,8 @@ jobs:
             NEXT_PUBLIC_LICENSE_CONSENT=${{ env.NEXT_PUBLIC_LICENSE_CONSENT }}
             NEXT_PUBLIC_TELEMETRY_KEY=${{ env.NEXT_PUBLIC_TELEMETRY_KEY }}
             DATABASE_URL=postgresql://${{ env.POSTGRES_USER }}:${{ env.POSTGRES_PASSWORD }}@${{ env.DATABASE_HOST }}/${{ env.POSTGRES_DB }}
-
+        if: ${{ !github.event.release.prerelease }}
+        
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
         


### PR DESCRIPTION
We currently mark pre-release on cal.com repo as `-rc` in suffix. In this PR, we see if the `RELEASE_TAG` contains `-rc`, and the `prerelease` property of the `createRelease` function is dynamically set based on that.

- We also only push to dockerhub if it isn't a prerelease by fetching the value of `github.event.release.prerelease`. 
- We added flavor to meta to only tag latest if it isn't a prerelease using the value of `github.event.release.prerelease`