### PR TITLE
Changing build-time env variables to run-time only

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,12 +26,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        NEXT_PUBLIC_WEBAPP_URL: ${NEXT_PUBLIC_WEBAPP_URL}
-        NEXT_PUBLIC_LICENSE_CONSENT: ${NEXT_PUBLIC_LICENSE_CONSENT}
-        CALCOM_TELEMETRY_DISABLED: ${CALCOM_TELEMETRY_DISABLED}
-        NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
-        CALENDSO_ENCRYPTION_KEY: ${CALENDSO_ENCRYPTION_KEY}
-        DATABASE_URL: ${DATABASE_URL}
+      - DATABASE_URL
       network: stack
     restart: always
     networks:

--- a/scripts/replace-placeholder.sh
+++ b/scripts/replace-placeholder.sh
@@ -1,16 +1,22 @@
-FROM=$1
-TO=$2
-
-if [ "${FROM}" = "${TO}" ]; then
-    echo "Nothing to replace, the value is already set to ${TO}."
-
-    exit 0
-fi
-
-# Only peform action if $FROM and $TO are different.
-echo "Replacing all statically built instances of $FROM with $TO."
-
-find apps/web/.next/ apps/web/public -type f |
-while read file; do
-    sed -i "s|$FROM|$TO|g" "$file"
+#!/bin/sh
+ 
+# List of variables to replace
+VARIABLES="NEXT_PUBLIC_WEBAPP_URL NEXT_PUBLIC_LICENSE_CONSENT CALCOM_TELEMETRY_DISABLED NEXTAUTH_SECRET CALENDSO_ENCRYPTION_KEY DATABASE_URL"
+ 
+for VAR in $VARIABLES; do
+    # Retrieve the current value of the variable
+    TO_VALUE=$(eval echo \$$VAR)
+ 
+    # Only proceed if the variable is set and not empty
+    if [ ! -z "$TO_VALUE" ]; then
+        FROM_PLACEHOLDER="PLACEHOLDER_${VAR}"
+        echo "Replacing $FROM_PLACEHOLDER with $TO_VALUE"
+ 
+        find apps/web/.next/ apps/web/public -type f |
+        while read file; do
+            sed -i "s|$FROM_PLACEHOLDER|$TO_VALUE|g" "$file"
+        done
+    else
+        echo "Variable $VAR is not set. Skipping replacement for $VAR."
+    fi
 done

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -3,7 +3,7 @@ set -x
 
 # Replace the statically built BUILT_NEXT_PUBLIC_WEBAPP_URL with run-time NEXT_PUBLIC_WEBAPP_URL
 # NOTE: if these values are the same, this will be skipped.
-scripts/replace-placeholder.sh "$BUILT_NEXT_PUBLIC_WEBAPP_URL" "$NEXT_PUBLIC_WEBAPP_URL"
+scripts/replace-placeholder.sh
 
 scripts/wait-for-it.sh ${DATABASE_HOST} -- echo "database is up"
 npx prisma migrate deploy --schema /calcom/packages/prisma/schema.prisma


### PR DESCRIPTION
## What does this PR do?
Fixes [CAL-2635] by changing build-time environment variables to run-time.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
### Scenario 1: Verify Image Build and Container Run
- Build the image with ([here](https://pastebin.com/00UMz24U) you can see the logs):
`docker build --build-arg DATABASE_URL="postgresql://postgres:@host.docker.internal:5432/calendso" -t calcom-image-test .`

- Run a container using the image with runtime variables:
`docker run \ -e NEXTAUTH_SECRET="your_secret" \ -e DA
TABASE_URL="your_database_url" \ -e CALENDSO_ENCRYPTION_KEY="your_key" \ -e NEXT_PUBLIC_WEBAPP_URL="http://localhost:3000" calcom-image-test`

- Expected Outcome: The container should start successfully with the provided variables. Test with invalid data to verify failure at runtime.

### Scenario 2: Docker Compose
- Start the setup using:
`docker compose up -d` 

## Disclaimer
At this point Build arguments cannot be removed as there are checks in the background for the existence of these variables.
While this makes sense when setting those variables build-time, when requiring the variables to be set only run-time, these checks might be redundant. 
