### PR TITLE
Fix missing `embed` folder in `web/public`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ RUN npx turbo prune --scope=@calcom/web --docker
 RUN yarn install
 RUN yarn db-deploy
 RUN yarn --cwd packages/prisma seed-app-store
+# Build and make embed servable from web/public/embed folder
+RUN yarn --cwd packages/embeds/embed-core workspace @calcom/embed-core run build
 RUN yarn --cwd apps/web workspace @calcom/web run build
 
 # RUN yarn plugin import workspace-tools && \


### PR DESCRIPTION
Fixes #360

Possible regression from https://github.com/calcom/docker/pull/359. As we stopped using `turbo` for build, `embed-core` dependency of @calcom/web stopped building causing the `public/embed` folder to be not generated.

