### PR TITLE
fix: Issue with out-of-sync yarn.lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,9 @@ ARG NEXT_PUBLIC_WEBAPP_URL=http://localhost:3000
 
 ENV NODE_ENV production
 
-COPY calcom/package.json calcom/.yarnrc.yml calcom/yarn.lock calcom/turbo.json ./
+COPY calcom/package.json calcom/.yarnrc.yml calcom/turbo.json ./
 COPY calcom/.yarn ./.yarn
+COPY --from=builder /calcom/yarn.lock ./yarn.lock
 COPY --from=builder /calcom/node_modules ./node_modules
 COPY --from=builder /calcom/packages ./packages
 COPY --from=builder /calcom/apps/web ./apps/web


### PR DESCRIPTION
This will use the yarn.lock after yarn install to avoid any issues with having missing dependencies from the yarn.lock file. This is simply a stop-gap until we get better checks in place to know the yarn.lock file isn't being merged to main with missing dependencies.