### PR TITLE
chore: Add EMAIL_FROM_NAME to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,7 @@ ZOOM_CLIENT_SECRET=
 
 # E-mail settings
 # Configures the global From: header whilst sending emails.
+EMAIL_FROM_NAME=YourOrganizationName
 EMAIL_FROM=notifications@example.com
 
 # Configure SMTP settings (@see https://nodemailer.com/smtp/).


### PR DESCRIPTION
This PR adds the `EMAIL_FROM_NAME` field to the .env.example file.

**Why?**
To maintain consistency in the "From" field of outgoing emails. Without setting `EMAIL_FROM_NAME`, emails may appear with different senders, such as `Cal.com <user@email.com>` or `LoggedInUser <user@email.com>`.

After some trial and error, I discovered that both `EMAIL_FROM` and `EMAIL_FROM_NAME` need to be defined for consistent email formatting, though this was not previously documented. Adding this to the example environment file ensures that developers are aware of it and can set it appropriately.