### PR TITLE
doc(README): Add --recurse-submodules  flag to git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you are evaluating Cal.com or running with minimal to no modifications, this 
 1. Clone calcom/docker
 
     ```bash
-    git clone https://github.com/calcom/docker.git
+    git clone --recurse-submodules https://github.com/calcom/docker.git
     ```
 
 2. Change into the directory


### PR DESCRIPTION
The documentation makes no mention of initializing and updating submodules. A user that is following along the tutorial might not look at the repository to see that `calcom` directory is a submodule and they need to initialize it before running docker compose.