### PR TITLE
added missing nc command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,10 @@ RUN scripts/replace-placeholder.sh http://NEXT_PUBLIC_WEBAPP_URL_PLACEHOLDER ${N
 
 FROM node:18 as runner
 
+RUN apt-get update \
+    && apt-get install -y netcat-openbsd \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /calcom
 COPY --from=builder-two /calcom ./


### PR DESCRIPTION
The netcat command is missing in `wait-for-it.sh`.

When using the official docker container `start.sh` script has a race condition:

`scripts/wait-for-it.sh ${DATABASE_HOST} -- echo "database is up"` is not blocking the execution of the start process - the migrate command fails.

I think it was not discovered during your regular development process, as the database is always created during build time `RUN yarn db-deploy`.

My patch hopefully fixes the root cause of the official docker images.