### PR TITLE
fix: updated database plan name

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -23,4 +23,4 @@ services:
 
 databases:
   - name: cal-postgres
-    plan: starter
+    plan: basic-1gb


### PR DESCRIPTION
[render one click deploy issue](https://github.com/calcom/cal.com/issues/19603)

For this issue , I update the postgres plan from starter(legacy) -> basic-1gb , which is the equivalent new plan type. This should now work with one click deploy on render