### PR TITLE
Fix GHA docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,12 @@ COPY calcom/packages ./packages
 COPY calcom/tests ./tests
 
 RUN yarn config set httpTimeout 1200000
-RUN npx turbo prune --scope=@calcom/web --docker
+RUN npx turbo prune --scope=@calcom/web --scope=@calcom/trpc --docker
 RUN yarn install
 RUN yarn db-deploy
 RUN yarn --cwd packages/prisma seed-app-store
 # Build and make embed servable from web/public/embed folder
+RUN yarn workspace @calcom/trpc run build
 RUN yarn --cwd packages/embeds/embed-core workspace @calcom/embed-core run build
 RUN yarn --cwd apps/web workspace @calcom/web run build
 


### PR DESCRIPTION
This should fix the latest issue of versions not being pushed to Docker Hub. Build time remains roughly the same. Not sure if we should back-date with all of the missing versions, maybe we can merge this fix to all the release branches and see if that backfills the images on Docker Hub.