### PR TITLE
fix: latest build issues 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV NEXT_PUBLIC_WEBAPP_URL=http://NEXT_PUBLIC_WEBAPP_URL_PLACEHOLDER \
     NODE_OPTIONS=--max-old-space-size=${MAX_OLD_SPACE_SIZE} \
     BUILD_STANDALONE=true
 
-COPY calcom/package.json calcom/yarn.lock calcom/.yarnrc.yml calcom/playwright.config.ts calcom/turbo.json calcom/git-init.sh calcom/git-setup.sh calcom/i18n.json ./
+COPY calcom/package.json calcom/yarn.lock calcom/.yarnrc.yml calcom/playwright.config.ts calcom/turbo.json calcom/i18n.json ./
 COPY calcom/.yarn ./.yarn
 COPY calcom/apps/web ./apps/web
 COPY calcom/apps/api/v2 ./apps/api/v2
@@ -31,8 +31,6 @@ COPY calcom/tests ./tests
 RUN yarn config set httpTimeout 1200000
 RUN npx turbo prune --scope=@calcom/web --scope=@calcom/trpc --docker
 RUN yarn install
-RUN yarn db-deploy
-RUN yarn --cwd packages/prisma seed-app-store
 # Build and make embed servable from web/public/embed folder
 RUN yarn workspace @calcom/trpc run build
 RUN yarn --cwd packages/embeds/embed-core workspace @calcom/embed-core run build

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,7 +33,6 @@ services:
         CALENDSO_ENCRYPTION_KEY: ${CALENDSO_ENCRYPTION_KEY}
         DATABASE_URL: ${DATABASE_URL}
         DATABASE_DIRECT_URL: ${DATABASE_URL}
-      network: stack
     restart: always
     networks:
       - stack


### PR DESCRIPTION
Fixes the following issues :

File - `docker-compose.yaml`
- As per latest docker desktop versions and buildkit version , `network: stack` field is not required under build. This was required in legacy versions. 
- This avoids prefix `DOCKER_BUILDKIT=0` in docker compose build command or docker compose up command.
Reference - https://github.com/calcom/docker/discussions/440

File - `Dockerfile`
1. build process is trying to run database migrations (yarn db-deploy) during the image build phase. This won't work because the database service isn't available during build time.
The following line - 
RUN yarn db-deploy
RUN yarn --cwd packages/prisma seed-app-store
are executed even before the database container is ready or started. Hence the issue after prisma migrations.
Also as reported here -  https://github.com/calcom/docker/discussions/440
The `scripts/start.sh` script already has these commands and executes after db is ready, hence removing these commands from docker file.

2. The files git-init.sh and git-setup.sh are removed (from this PR https://github.com/calcom/cal.com/pull/20731)
Hence the docker build is failing at a COPY cmd while trying to copy these files.
