### PR TITLE
Fix secrets setup to resolve 2FA and encryption key issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,9 +20,13 @@ NEXT_PUBLIC_API_V2_URL=http://localhost:5555/api/v2
 
 # It is highly recommended that the NEXTAUTH_SECRET must be overridden and very unique
 # Use `openssl rand -base64 32` to generate a key
+# IMPORTANT: Replace 'secret' with a secure value before running docker compose
 NEXTAUTH_SECRET=secret
 
-# Encryption key that will be used to encrypt CalDAV credentials, choose a random string, for example with `dd if=/dev/urandom bs=1K count=1 | md5sum`
+# Encryption key that will be used to encrypt CalDAV credentials and 2FA data
+# CRITICAL: Must be at least 24 characters for 2FA to work properly
+# Use `openssl rand -base64 24` to generate a secure key
+# IMPORTANT: Replace 'secret' with a secure value before running docker compose
 CALENDSO_ENCRYPTION_KEY=secret
 
 # Deprecation note: JWT_SECRET is no longer used

--- a/README.md
+++ b/README.md
@@ -61,15 +61,34 @@ If you are evaluating Cal.com or running with minimal to no modifications, this 
     cd docker
     ```
 
-3. Prepare your configuration: Rename `.env.example` to `.env` and then update `.env`
+3. Prepare your configuration: 
 
+    **Option A: Automatic Setup (Recommended)**
+    ```bash
+    ./setup.sh
+    ```
+    This script will create your `.env` file and generate secure secrets automatically.
+
+    **Option B: Manual Setup**
     ```bash
     cp .env.example .env
     ```
+    
+    **⚠️ CRITICAL: Generate secure secrets before proceeding**
+    
+    The default `.env.example` contains placeholder values that will cause issues, particularly with 2FA functionality. You MUST generate proper secrets:
+    
+    ```bash
+    # Generate NEXTAUTH_SECRET (32 characters)
+    openssl rand -base64 32
+    
+    # Generate CALENDSO_ENCRYPTION_KEY (24 characters - required for 2FA)
+    openssl rand -base64 24
+    ```
+    
+    Update these values in your `.env` file, replacing the default `secret` values.
 
-    Most configurations can be left as-is, but for configuration options see [Important Run-time variables](#important-run-time-variables) below.
-
-    Update the appropriate values in your .env file, then proceed.
+    Most other configurations can be left as-is, but for additional configuration options see [Important Run-time variables](#important-run-time-variables) below.
 
 4. (optional) Pre-Pull the images by running the following command:
 

--- a/docker-compose.enhanced.yaml
+++ b/docker-compose.enhanced.yaml
@@ -1,0 +1,103 @@
+# Enhanced Docker Compose with automatic secret generation
+# Use this instead of docker-compose.yaml for automatic setup
+
+volumes:
+  database-data:
+
+networks:
+  stack:
+    name: stack
+    external: false
+
+services:
+  # Secret generation service
+  setup:
+    image: alpine:latest
+    volumes:
+      - .:/workspace
+    working_dir: /workspace
+    command: >
+      sh -c "
+        apk add --no-cache openssl &&
+        if [ ! -f .env ]; then
+          echo 'Creating .env from .env.example...' &&
+          cp .env.example .env
+        fi &&
+        if grep -q 'NEXTAUTH_SECRET=secret' .env; then
+          echo 'Generating NEXTAUTH_SECRET...' &&
+          NEXTAUTH_SECRET=$$(openssl rand -base64 32) &&
+          sed -i \"s/NEXTAUTH_SECRET=secret/NEXTAUTH_SECRET=$$NEXTAUTH_SECRET/\" .env
+        fi &&
+        if grep -q 'CALENDSO_ENCRYPTION_KEY=secret' .env; then
+          echo 'Generating CALENDSO_ENCRYPTION_KEY (24 chars for 2FA)...' &&
+          CALENDSO_ENCRYPTION_KEY=$$(openssl rand -base64 24) &&
+          sed -i \"s/CALENDSO_ENCRYPTION_KEY=secret/CALENDSO_ENCRYPTION_KEY=$$CALENDSO_ENCRYPTION_KEY/\" .env
+        fi &&
+        echo 'Setup complete! Secrets generated in .env file.'
+      "
+
+  database:
+    container_name: database
+    image: postgres
+    restart: always
+    volumes:
+      - database-data:/var/lib/postgresql/data/
+    env_file: .env
+    networks:
+      - stack
+    depends_on:
+      setup:
+        condition: service_completed_successfully
+
+  calcom:
+    image: calcom.docker.scarf.sh/calcom/cal.com
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_WEBAPP_URL: ${NEXT_PUBLIC_WEBAPP_URL}
+        NEXT_PUBLIC_API_V2_URL: ${NEXT_PUBLIC_API_V2_URL}
+        NEXT_PUBLIC_LICENSE_CONSENT: ${NEXT_PUBLIC_LICENSE_CONSENT}
+        NEXT_PUBLIC_WEBSITE_TERMS_URL: ${NEXT_PUBLIC_WEBSITE_TERMS_URL}
+        NEXT_PUBLIC_WEBSITE_PRIVACY_POLICY_URL: ${NEXT_PUBLIC_WEBSITE_PRIVACY_POLICY_URL}
+        CALCOM_TELEMETRY_DISABLED: ${CALCOM_TELEMETRY_DISABLED}
+        NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
+        CALENDSO_ENCRYPTION_KEY: ${CALENDSO_ENCRYPTION_KEY}
+        DATABASE_URL: ${DATABASE_URL}
+        DATABASE_DIRECT_URL: ${DATABASE_URL}
+    restart: always
+    networks:
+      - stack
+    ports:
+      - 3000:3000
+    env_file: .env
+    environment:
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}/${POSTGRES_DB}
+      - DATABASE_DIRECT_URL=${DATABASE_URL}
+    depends_on:
+      setup:
+        condition: service_completed_successfully
+      database:
+        condition: service_started
+
+  # Optional Prisma Studio
+  studio:
+    image: calcom.docker.scarf.sh/calcom/cal.com
+    restart: always
+    networks:
+      - stack
+    ports:
+      - 5555:5555
+    env_file: .env
+    environment:
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}/${POSTGRES_DB}
+      - DATABASE_DIRECT_URL=${DATABASE_URL}
+    depends_on:
+      setup:
+        condition: service_completed_successfully
+      database:
+        condition: service_started
+    command:
+      - npx
+      - prisma
+      - studio

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Cal.com Docker Setup Script
+# This script generates secure secrets and prepares the environment
+
+set -e
+
+ENV_FILE=".env"
+
+echo "🚀 Setting up Cal.com Docker environment..."
+
+# Check if .env exists, if not copy from example
+if [ ! -f "$ENV_FILE" ]; then
+    echo "📋 Creating .env file from .env.example..."
+    cp .env.example .env
+fi
+
+# Generate NEXTAUTH_SECRET if it's still the default
+if grep -q "NEXTAUTH_SECRET=secret" "$ENV_FILE"; then
+    echo "🔐 Generating NEXTAUTH_SECRET..."
+    NEXTAUTH_SECRET=$(openssl rand -base64 32)
+    sed -i "s/NEXTAUTH_SECRET=secret/NEXTAUTH_SECRET=$NEXTAUTH_SECRET/" "$ENV_FILE"
+fi
+
+# Generate CALENDSO_ENCRYPTION_KEY if it's still the default
+if grep -q "CALENDSO_ENCRYPTION_KEY=secret" "$ENV_FILE"; then
+    echo "🔑 Generating CALENDSO_ENCRYPTION_KEY (24 characters for 2FA support)..."
+    CALENDSO_ENCRYPTION_KEY=$(openssl rand -base64 24)
+    sed -i "s/CALENDSO_ENCRYPTION_KEY=secret/CALENDSO_ENCRYPTION_KEY=$CALENDSO_ENCRYPTION_KEY/" "$ENV_FILE"
+fi
+
+echo "✅ Environment setup complete!"
+echo ""
+echo "🔧 Generated secrets:"
+echo "   - NEXTAUTH_SECRET: ✓"
+echo "   - CALENDSO_ENCRYPTION_KEY: ✓ (24 chars - fixes 2FA issue)"
+echo ""
+echo "📝 Next steps:"
+echo "   1. Review and customize other settings in .env"
+echo "   2. Run: docker compose up --build"
+echo ""
+echo "⚠️  Important: The generated secrets are saved in .env"
+echo "   Keep this file secure and don't commit it to version control!"


### PR DESCRIPTION
## Problem

Multiple users are experiencing issues with 2FA setup and admin access due to insufficient encryption key length. Issues #389 and #333 report `ERR_CRYPTO_INVALID_KEYLEN` errors when trying to enable 2FA.

## Root Cause

The default `CALENDSO_ENCRYPTION_KEY=secret` (6 characters) in `.env.example` is too short for crypto operations. The application requires at least 24 characters for proper encryption functionality.

## Solution

This PR provides multiple approaches to fix the secrets setup:

### 1. Automatic Setup Script (`setup.sh`)
- Generates secure 24-character `CALENDSO_ENCRYPTION_KEY`
- Generates secure 32-character `NEXTAUTH_SECRET`
- Creates `.env` file from example if it doesn't exist
- Provides clear feedback to users

### 2. Enhanced Documentation
- Updated README.md with clear setup instructions
- Added warnings about default secrets in `.env.example`
- Provided manual generation commands

### 3. Enhanced Docker Compose (Optional)
- `docker-compose.enhanced.yaml` with automatic secret generation
- Uses init container to generate secrets before main services start

## Testing

The fix addresses the specific error:
```
RangeError: Invalid key length
at symmetricEncrypt (/calcom/apps/web/.next/server/chunks/69559.js:1:278)
at handler (/calcom/apps/web/.next/server/pages/api/auth/two-factor/totp/setup.js:1:3199)
code: 'ERR_CRYPTO_INVALID_KEYLEN'
```

## Issues Fixed

- Fixes #389: Admin password and 2FA issues
- Fixes #333: Invalid key length on CALENDSO_ENCRYPTION_KEY
- Addresses #88: SECRET issue (related to NEXTAUTH_SECRET)

## Usage

**Recommended approach:**
```bash
./setup.sh
docker compose up --build
```

**Manual approach:**
```bash
cp .env.example .env
# Edit .env and replace secrets with:
openssl rand -base64 32  # for NEXTAUTH_SECRET
openssl rand -base64 24  # for CALENDSO_ENCRYPTION_KEY
docker compose up --build
```