### PR TITLE
Temporarily suffix ARM images

### DIFF
--- a/.github/workflows/docker-build-push-dockerhub-arm.yml
+++ b/.github/workflows/docker-build-push-dockerhub-arm.yml
@@ -84,10 +84,10 @@ jobs:
           # Add flavor latest only on full releases, not on pre-releases
           flavor: |
             latest=false
-            suffix=arm
+            suffix=-test-arm
           # flavor: |
           #   latest=${{ !github.event.release.prerelease }}
-          #   suffix=test-arm
+          #   suffix=-arm
 
       - name: Copy env
         run: |


### PR DESCRIPTION
This will temporarily suffix ARM images for testing, before updating the pipelines to merge and GA multi-arch images.

We will first verify the build and tags, and then enable the push in a subsequent PR, as extra protection to prevent image conflicts.