### PR TITLE
Add CSP_Policy to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,3 +61,6 @@ EMAIL_SERVER_USER=email_user
 EMAIL_SERVER_PASSWORD=email_password
 
 NODE_ENV=production
+
+# Content Security Policy (Possible values: strict or non-strict)
+CSP_POLICY=


### PR DESCRIPTION
Closes #211 by porting the CSP_POLICY example parameter (and possible values) over from the main repository.